### PR TITLE
add `css` and `text` format to snippet check

### DIFF
--- a/lib/learn_linter/readme_linter.rb
+++ b/lib/learn_linter/readme_linter.rb
@@ -35,7 +35,7 @@ class ReadmeLinter
   def self.lint_lines(lines, learn_error)
     lines.each do |line_num, line_content|
       if line_content.match(/``/)
-        if !(line_content.match(/^```(ruby|bash|swift|html|erb|js|javascript|objc|java|sql)?$/)) 
+        if !(line_content.match(/^```(ruby|bash|swift|html|erb|js|javascript|objc|java|sql|css|text)?$/)) 
           learn_error.valid_readme[:message] << "INVALID CODE SNIPPET - line #{line_num}: #{line_content}"
         end
       end


### PR DESCRIPTION
I could be mistaken here and these formats would cause issues? But otherwise would be spectacular if these formats could be allowed. Thanks! 
(Bumped into a failed linter trying to update a labs Readme with those snippets though the text format was already in the Readme)
@SophieDeBenedetto  